### PR TITLE
Fix ERC165 implementation problem

### DIFF
--- a/contracts/MultiResource_EIP/MultiResourceToken.sol
+++ b/contracts/MultiResource_EIP/MultiResourceToken.sol
@@ -75,7 +75,10 @@ contract MultiResourceToken is Context, IMultiResource {
 
 
     function supportsInterface(bytes4 interfaceId) public pure returns (bool) {
-        return interfaceId == type(IMultiResource).interfaceId;
+        return 
+            interfaceId == type(IMultiResource).interfaceId ||
+            interfaceId == type(IERC721).interfaceId ||
+            interfaceId == type(IERC165).interfaceId;
     }
 
 

--- a/test/multiresource.ts
+++ b/test/multiresource.ts
@@ -36,6 +36,24 @@ describe('MultiResource', async () => {
     });
   });
 
+  describe('ERC165 check', async function () {
+    it('can support IERC165', async function () {
+      expect(await token.supportsInterface('0x01ffc9a7')).to.equal(true);
+    });
+
+    it('can support IERC721', async function () {
+      expect(await token.supportsInterface('0x80ac58cd')).to.equal(true);
+    });
+
+    it('can support IMultiResource', async function () {
+      expect(await token.supportsInterface('0x01c813f6')).to.equal(true);
+    });
+
+    it('cannot support other interfaceId', async function () {
+      expect(await token.supportsInterface('0xffffffff')).to.equal(false);
+    });
+  });
+
   describe('Resource storage', async function () {
     it('can add resource', async function () {
       const id = ethers.utils.hexZeroPad('0x1111', 8);


### PR DESCRIPTION
I've noticed that there're some problems with ERC165 implementation in MultiResource contract.
It should also support IERC165 and IERC721 to make it actually work.

The problem seems to be here, too:
https://github.com/rmrk-team/evm/tree/dev/contracts/RMRK

I refer to the implementation here.
https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol#L52