### PR TITLE
Resource approvals

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ interface IMultiResource {
         uint128 customResourceId
     );
 
+    /// @dev This emits when the approved address for resources for an NFT is
+    ///  changed or reaffirmed. The zero address indicates there is no approved
+    ///  address. When a Transfer event emits, this also indicates that the
+    ///  approved address for resources for that NFT (if any) is reset to none.
+    event Approval(address indexed _owner, address indexed _approved, uint256 indexed _tokenId);
+
+    /// @dev This emits when an operator for resources is enabled or disabled
+    ///  for an owner. The operator can manage resources for all NFTs of the
+    /// owner.
+    event ApprovalForAll(address indexed _owner, address indexed _operator, bool _approved);
+
     /*
     @notice Accepts the resource from pending.
     @dev Moves the resource from the pending array to the accepted array. Array
@@ -224,6 +235,35 @@ interface IMultiResource {
     @return the string URI of the token
     */
     function tokenURI(uint256 tokenId) external view returns (string memory);
+
+    /// @notice Change or reaffirm the approved address for resources for an NFT
+    /// @dev The zero address indicates there is no approved address.
+    ///  Throws unless `msg.sender` is the current NFT owner, or an authorized
+    ///  operator of the current owner. Emits ApprovalForResources event.
+    /// @param to The new approved NFT controller
+    /// @param tokenId The NFT to approve
+    function approveForResources(address to, uint256 tokenId) external payable;
+
+    /// @notice Enable or disable approval for a third party ("operator") to manage
+    ///  resources for all of the `msg.sender`'s assets
+    /// @dev Emits the ApprovalForAllForResources event. The contract MUST allow
+    ///  multiple operators per owner.
+    /// @param operator Address to add to the set of authorized operators
+    /// @param approved True if the operator is approved, false to revoke approval
+    function setApprovalForAllForResources(address operator, bool approved) external;
+
+    /// @notice Get the approved address for resources for a single NFT
+    /// @dev Throws if `tokenId` is not a valid NFT.
+    /// @param tokenId The NFT to find the approved address for
+    /// @return The approved address for this NFT, or the zero address if there is none
+    function getApprovedForResources(uint256 tokenId) external view returns (address);
+
+    /// @notice Query if an address is an authorized operator for resources of
+    ///  another address
+    /// @param owner The address that owns the NFTs
+    /// @param operator The address that acts on behalf of the owner
+    /// @return True if `operator` is an approved operator for `owner`, false otherwise
+    function isApprovedForAllForResources(address owner, address operator) external view returns (bool);
 
 }
 

--- a/contracts/MultiResource_EIP/MultiResourceToken.sol
+++ b/contracts/MultiResource_EIP/MultiResourceToken.sol
@@ -165,7 +165,7 @@ contract MultiResourceToken is Context, IERC721, IMultiResource {
     ) public virtual view returns (address) {
         require(
             _exists(tokenId),
-            "MultiResource: approved for query for nonexistent token"
+            "MultiResource: approved query for nonexistent token"
         );
         return _tokenApprovalsForResources[tokenId];
     }
@@ -327,6 +327,7 @@ contract MultiResourceToken is Context, IERC721, IMultiResource {
 
         // Clear approvals
         _approve(address(0), tokenId);
+        _approveForResources(address(0), tokenId);
 
         _balances[owner] -= 1;
         delete _owners[tokenId];
@@ -355,6 +356,7 @@ contract MultiResourceToken is Context, IERC721, IMultiResource {
 
         // Clear approvals from the previous owner
         _approve(address(0), tokenId);
+        _approveForResources(address(0), tokenId);
 
         _balances[from] -= 1;
         _balances[to] += 1;

--- a/contracts/MultiResource_EIP/MultiResourceToken.sol
+++ b/contracts/MultiResource_EIP/MultiResourceToken.sol
@@ -36,6 +36,14 @@ contract MultiResourceToken is Context, IERC721, IMultiResource {
     // Mapping from owner to operator approvals
     mapping(address => mapping(address => bool)) private _operatorApprovals;
 
+    // Mapping from token ID to approved address for resources
+    mapping(uint256 => address) internal _tokenApprovalsForResources;
+
+    // Mapping from owner to operator approvals for resources
+    mapping(
+        address => mapping(address => bool)
+    ) internal _operatorApprovalsForResources;
+
     //mapping of uint64 Ids to resource object
     mapping(uint64 => Resource) private _resources;
 
@@ -128,16 +136,38 @@ contract MultiResourceToken is Context, IERC721, IMultiResource {
         _approve(to, tokenId);
     }
 
+    function approveForResources(address to, uint256 tokenId) external virtual {
+        address owner = ownerOf(tokenId);
+        require(to != owner, "MultiResource: approval to current owner");
+        require(
+            _msgSender() == owner
+            || isApprovedForAllForResources(owner, _msgSender()),
+            "MultiResource: approve caller is not owner nor approved for all"
+        );
+        _approveForResources(to, tokenId);
+    }
+
 
     function getApproved(
         uint256 tokenId)
-     public view virtual override returns (address) {
+    public view virtual override returns (address) {
         require(
             _exists(tokenId),
             "MultiResource: approved query for nonexistent token"
         );
 
         return _tokenApprovals[tokenId];
+    }
+
+
+    function getApprovedForResources(
+        uint256 tokenId
+    ) public virtual view returns (address) {
+        require(
+            _exists(tokenId),
+            "MultiResource: approved for query for nonexistent token"
+        );
+        return _tokenApprovalsForResources[tokenId];
     }
 
 
@@ -153,6 +183,19 @@ contract MultiResourceToken is Context, IERC721, IMultiResource {
         address operator
     ) public view virtual override returns (bool) {
         return _operatorApprovals[owner][operator];
+    }
+
+    function setApprovalForAllForResources(
+        address operator,
+        bool approved
+    ) public virtual override {
+        _setApprovalForAllForResources(_msgSender(), operator, approved);
+    }
+
+    function isApprovedForAllForResources(
+        address owner, address operator
+    ) public virtual view returns (bool) {
+        return _operatorApprovalsForResources[owner][operator];
     }
 
 
@@ -218,13 +261,28 @@ contract MultiResourceToken is Context, IERC721, IMultiResource {
     ) internal view virtual returns (bool) {
         require(
             _exists(tokenId),
-            "MultiResource: operator query for nonexistent token"
+            "MultiResource: approved query for nonexistent token"
         );
         address owner = ownerOf(tokenId);
         return (
             spender == owner
             || isApprovedForAll(owner, spender)
             || getApproved(tokenId) == spender
+        );
+    }
+
+    function _isApprovedForResourcesOrOwner(
+        address user, uint256 tokenId
+    ) internal view virtual returns (bool) {
+        require(
+            _exists(tokenId),
+            "MultiResource: approved query for nonexistent token"
+        );
+        address owner = ownerOf(tokenId);
+        return (
+            user == owner
+            || isApprovedForAllForResources(owner, user)
+            || getApprovedForResources(tokenId) == user
         );
     }
 
@@ -313,6 +371,12 @@ contract MultiResourceToken is Context, IERC721, IMultiResource {
         emit Approval(ownerOf(tokenId), to, tokenId);
     }
 
+    function _approveForResources(
+        address to, uint256 tokenId
+    ) internal virtual {
+        _tokenApprovalsForResources[tokenId] = to;
+        emit ApprovalForResources(ownerOf(tokenId), to, tokenId);
+    }
 
     function _setApprovalForAll(
         address owner,
@@ -322,6 +386,17 @@ contract MultiResourceToken is Context, IERC721, IMultiResource {
         require(owner != operator, "MultiResource: approve to caller");
         _operatorApprovals[owner][operator] = approved;
         emit ApprovalForAll(owner, operator, approved);
+    }
+
+
+    function _setApprovalForAllForResources(
+        address owner,
+        address operator,
+        bool approved
+    ) internal virtual {
+        require(owner != operator, "MultiResource: approve to caller");
+        _operatorApprovalsForResources[owner][operator] = approved;
+        emit ApprovalForAllForResources(owner, operator, approved);
     }
 
 
@@ -352,7 +427,9 @@ contract MultiResourceToken is Context, IERC721, IMultiResource {
 
             catch (bytes memory reason) {
                 if (reason.length == 0) {
-                    revert("MultiResource: transfer to non MultiResource Receiver implementer");
+                    revert(
+                        "MultiResource: transfer to non MultiResource Receiver implementer"
+                    );
                 } else {
                     assembly {
                         revert(add(32, reason), mload(reason))
@@ -392,8 +469,8 @@ contract MultiResourceToken is Context, IERC721, IMultiResource {
             "MultiResource: index out of bounds"
         );
         require(
-            _msgSender() == ownerOf(tokenId),
-            "MultiResource: not owner"
+            _isApprovedForResourcesOrOwner(_msgSender(), tokenId),
+            "MultiResource: not owner or approved"
         );
         uint64 resourceId = _pendingResources[tokenId][index];
         _pendingResources[tokenId].removeItemByIndex(index);
@@ -421,8 +498,8 @@ contract MultiResourceToken is Context, IERC721, IMultiResource {
             "MultiResource: Pending resource index out of range"
         );
         require(
-            _msgSender() == ownerOf(tokenId),
-            "MultiResource: not owner"
+            _isApprovedForResourcesOrOwner(_msgSender(), tokenId),
+            "MultiResource: not owner or approved"
         );
 
         uint64 resourceId = _pendingResources[tokenId][index];
@@ -435,8 +512,8 @@ contract MultiResourceToken is Context, IERC721, IMultiResource {
 
     function rejectAllResources(uint256 tokenId) external virtual {
         require(
-            _msgSender() == ownerOf(tokenId),
-            "MultiResource: not owner"
+            _isApprovedForResourcesOrOwner(_msgSender(), tokenId),
+            "MultiResource: not owner or approved"
         );
         uint256 len = _pendingResources[tokenId].length;
         for (uint i; i<len;) {
@@ -458,8 +535,8 @@ contract MultiResourceToken is Context, IERC721, IMultiResource {
             "MultiResource: Bad priority list length"
         );
         require(
-            _msgSender() == ownerOf(tokenId),
-            "MultiResource: not owner"
+            _isApprovedForResourcesOrOwner(_msgSender(), tokenId),
+            "MultiResource: not owner or approved"
         );
         _activeResourcePriorities[tokenId] = priorities;
 

--- a/contracts/MultiResource_EIP/interfaces/IMultiResource.sol
+++ b/contracts/MultiResource_EIP/interfaces/IMultiResource.sol
@@ -42,6 +42,18 @@ interface IMultiResource {
         uint128 customResourceId
     );
 
+    event ApprovalForResources(
+        address indexed owner,
+        address indexed approved,
+        uint256 indexed tokenId
+    );
+
+    event ApprovalForAllForResources(
+        address indexed owner,
+        address indexed operator,
+        bool approved
+    );
+
     function acceptResource(uint256 tokenId, uint256 index) external;
 
     function rejectResource(uint256 tokenId, uint256 index) external;
@@ -99,4 +111,19 @@ interface IMultiResource {
     function getFullPendingResources(
         uint256 tokenId
     ) external view returns (Resource[] memory);
+
+    // Approvals
+    function approveForResources(address to, uint256 tokenId) external;
+
+    function getApprovedForResources(
+        uint256 tokenId
+    ) external view returns (address);
+
+    function setApprovalForAllForResources(
+        address operator, bool approved
+    ) external;
+
+    function isApprovedForAllForResources(
+        address owner, address operator
+    ) external view returns (bool);
 }

--- a/contracts/MultiResource_EIP/mocks/MultiResourceTokenMock.sol
+++ b/contracts/MultiResource_EIP/mocks/MultiResourceTokenMock.sol
@@ -42,6 +42,14 @@ contract MultiResourceTokenMock is MultiResourceToken {
         _mint(to, tokenId);
     }
 
+    function transfer(address to, uint256 tokenId) external {
+        _transfer(msg.sender, to, tokenId);
+    }
+
+    function burn(uint256 tokenId) external {
+        _burn(tokenId);
+    }
+
     function addResourceToToken(
         uint256 tokenId,
         uint64 resourceId,

--- a/test/multiresource.ts
+++ b/test/multiresource.ts
@@ -4,7 +4,7 @@ import {
   MultiResourceTokenMock,
   ERC721ReceiverMock,
   NonReceiverMock,
-  MultiResourceReceiverMock
+  MultiResourceReceiverMock,
 } from '../typechain';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
@@ -53,7 +53,7 @@ describe('MultiResource', async () => {
     });
 
     it('can support IMultiResource', async function () {
-      expect(await token.supportsInterface('0xb925bcaf')).to.equal(true);
+      expect(await token.supportsInterface('0x4d6339c8')).to.equal(true);
     });
 
     it('cannot support other interfaceId', async function () {
@@ -62,7 +62,6 @@ describe('MultiResource', async () => {
   });
 
   describe('Check OnReceived ERC721 and Multiresource', async function () {
-
     it('Revert on transfer to non onERC721/onMultiresource implementer', async function () {
       const tokenId = 1;
       await token.mint(owner.address, tokenId);
@@ -71,13 +70,11 @@ describe('MultiResource', async () => {
       nonReceiver = await NonReceiver.deploy();
       await nonReceiver.deployed();
 
-      await expect(token.connect(owner)['safeTransferFrom(address,address,uint256)'](
-        owner.address,
-        nonReceiver.address,
-        1
-      )).to.be.revertedWith('MultiResource: transfer to non MultiResource Receiver implementer');
-
-
+      await expect(
+        token
+          .connect(owner)
+          ['safeTransferFrom(address,address,uint256)'](owner.address, nonReceiver.address, 1),
+      ).to.be.revertedWith('MultiResource: transfer to non MultiResource Receiver implementer');
     });
 
     it('onMultiResourceReceived callback on transfer', async function () {
@@ -88,11 +85,13 @@ describe('MultiResource', async () => {
       receiverMultiresource = await MRReceiver.deploy();
       await receiverMultiresource.deployed();
 
-      await token.connect(owner)['safeTransferFrom(address,address,uint256)'](
-        owner.address,
-        receiverMultiresource.address,
-        1
-      );
+      await token
+        .connect(owner)
+        ['safeTransferFrom(address,address,uint256)'](
+          owner.address,
+          receiverMultiresource.address,
+          1,
+        );
       expect(await token.ownerOf(1)).to.equal(receiverMultiresource.address);
     });
 
@@ -104,13 +103,10 @@ describe('MultiResource', async () => {
       receiver721 = await ERC721Receiver.deploy();
       await receiver721.deployed();
 
-      await token.connect(owner)['safeTransferFrom(address,address,uint256)'](
-        owner.address,
-        receiver721.address,
-        1
-      );
+      await token
+        .connect(owner)
+        ['safeTransferFrom(address,address,uint256)'](owner.address, receiver721.address, 1);
       expect(await token.ownerOf(1)).to.equal(receiver721.address);
-
     });
   });
 
@@ -255,9 +251,9 @@ describe('MultiResource', async () => {
       await token.mint(owner.address, tokenId);
       await addResources([resId]);
       await token.addResourceToToken(tokenId, resId, 0);
-      await expect(token.addResourceToToken(tokenId, ethers.BigNumber.from(resId), 0)).to.be.revertedWith(
-        'MultiResource: Resource already exists on token',
-      );
+      await expect(
+        token.addResourceToToken(tokenId, ethers.BigNumber.from(resId), 0),
+      ).to.be.revertedWith('MultiResource: Resource already exists on token');
     });
 
     it('cannot add too many resources to the same token', async function () {
@@ -405,7 +401,9 @@ describe('MultiResource', async () => {
         [ethers.BigNumber.from(resId2), metaURIDefault, customDefault],
       ]);
       // Overwrite should be gone
-      expect(await token.getResourceOverwrites(tokenId, pendingResources[0])).to.eql(ethers.BigNumber.from(0));
+      expect(await token.getResourceOverwrites(tokenId, pendingResources[0])).to.eql(
+        ethers.BigNumber.from(0),
+      );
     });
 
     it('can overwrite non existing resource to token, it could have been deleted', async function () {
@@ -585,7 +583,7 @@ describe('MultiResource', async () => {
     it('cannot set priorities for non existing token', async function () {
       const tokenId = 1;
       await expect(token.connect(addrs[1]).setPriority(tokenId, [])).to.be.revertedWith(
-        'ERC721: owner query for nonexistent token',
+        'MultiResource: approved query for nonexistent token',
       );
     });
   });


### PR DESCRIPTION
Splits approval for resource management from token management.
There is approval per token and approval for operator. Resource approvals are cleaned on transfer and burn as regular approvals.

It is used for these operations:
- Accept Resource
- Reject Resource
- Reject All Resources
- Set Priorities
Updates README and tests accordingly.